### PR TITLE
Fix FindRoutedEvent, Add unit tests for Avalonia

### DIFF
--- a/src/ReactiveUI.Avalonia/AvaloniaCreatesCommandBinding.cs
+++ b/src/ReactiveUI.Avalonia/AvaloniaCreatesCommandBinding.cs
@@ -86,11 +86,16 @@ internal class AvaloniaCreatesCommandBinding : ICreatesCommandBinding
 
     private static RoutedEvent? FindRoutedEvent(object target, string eventName)
     {
-        foreach (var routedEvent in RoutedEventRegistry.Instance.GetRegistered(target.GetType()))
+        // Search the type hierarchy so events declared on base classes (e.g., Button.Click on Button
+        // when the target is a derived type) can be located.
+        for (var type = target.GetType(); type is not null && typeof(InputElement).IsAssignableFrom(type); type = type.BaseType)
         {
-            if (routedEvent.Name == eventName)
+            foreach (var routedEvent in RoutedEventRegistry.Instance.GetRegistered(type))
             {
-                return routedEvent;
+                if (string.Equals(routedEvent.Name, eventName, StringComparison.Ordinal))
+                {
+                    return routedEvent;
+                }
             }
         }
 

--- a/src/Splat.Avalonia.Tests/AppBuilderExtensionsRegistrationTests.cs
+++ b/src/Splat.Avalonia.Tests/AppBuilderExtensionsRegistrationTests.cs
@@ -1,0 +1,156 @@
+using System.Reflection;
+using Avalonia;
+using Avalonia.Controls;
+using NUnit.Framework;
+using ReactiveUI;
+using Splat;
+
+namespace ReactiveUI.Avalonia.Tests
+{
+    public class AppBuilderExtensionsRegistrationTests
+    {
+        private interface ITestVm
+        {
+        }
+
+        [SetUp]
+        public void ResetLocator()
+        {
+            Assert.That(AppLocator.CurrentMutable, Is.Not.Null);
+
+            _ = new TestVm();
+            _ = new TestView();
+            _ = new ContractedTestView();
+
+            var serviceType = typeof(IViewFor<>).MakeGenericType(typeof(TestVm));
+            AppLocator.CurrentMutable.UnregisterCurrent(serviceType, null);
+            AppLocator.CurrentMutable.UnregisterCurrent(serviceType, "C1");
+        }
+
+        [Test]
+        public void RegisterViewsInternal_Registers_View_For_ViewModel_Using_Activator()
+        {
+            var resolver = AppLocator.CurrentMutable!;
+            var method = typeof(AppBuilderExtensions)
+                .GetMethod("RegisterViewsInternal", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(method, Is.Not.Null);
+
+            method!.Invoke(null, new object[] { resolver, new[] { typeof(AppBuilderExtensionsRegistrationTests).Assembly } });
+
+            var serviceType = typeof(IViewFor<>).MakeGenericType(typeof(TestVm));
+            var resolved = AppLocator.Current.GetService(serviceType);
+
+            Assert.That(resolved, Is.Not.Null);
+            Assert.That(serviceType.IsInstanceOfType(resolved), Is.True);
+        }
+
+        [Test]
+        public void RegisterViewsInternal_Honors_ViewContractAttribute()
+        {
+            var resolver = AppLocator.CurrentMutable!;
+            var method = typeof(AppBuilderExtensions)
+                .GetMethod("RegisterViewsInternal", BindingFlags.NonPublic | BindingFlags.Static);
+
+            method!.Invoke(null, new object[] { resolver, new[] { typeof(AppBuilderExtensionsRegistrationTests).Assembly } });
+
+            var serviceType = typeof(IViewFor<>).MakeGenericType(typeof(TestVm));
+            var resolvedDefault = AppLocator.Current.GetService(serviceType);
+            var resolvedC1 = AppLocator.Current.GetService(serviceType, "C1");
+
+            Assert.That(resolvedDefault, Is.Not.Null);
+            Assert.That(serviceType.IsInstanceOfType(resolvedDefault), Is.True);
+            Assert.That(resolvedC1, Is.InstanceOf<ContractedTestView>());
+        }
+
+        [Test]
+        public void RegisterViewsInternal_Prefers_DI_Resolution_Over_Activator()
+        {
+            var resolver = AppLocator.CurrentMutable!;
+
+            var diInstance = new DiBackedView();
+            resolver.RegisterConstant(diInstance, typeof(DiBackedView));
+
+            var method = typeof(AppBuilderExtensions)
+                .GetMethod("RegisterViewsInternal", BindingFlags.NonPublic | BindingFlags.Static);
+
+            method!.Invoke(null, new object[] { resolver, new[] { typeof(AppBuilderExtensionsRegistrationTests).Assembly } });
+
+            var serviceType = typeof(IViewFor<>).MakeGenericType(typeof(TestVm));
+            var resolved = AppLocator.Current.GetService(serviceType);
+
+            Assert.That(resolved, Is.SameAs(diInstance));
+        }
+
+        [Test]
+        public void RegisterReactiveUIViews_Throws_On_Null_Builder()
+        {
+            AppBuilder? builder = null;
+            Assert.Throws<ArgumentNullException>(() => builder!.RegisterReactiveUIViews());
+        }
+
+        [Test]
+        public void RegisterReactiveUIViewsFromAssemblyOf_Returns_Same_Builder()
+        {
+            var builder = AppBuilder.Configure<Application>();
+            var result = builder.RegisterReactiveUIViewsFromAssemblyOf<AppBuilderExtensionsRegistrationTests>();
+            Assert.That(result, Is.SameAs(builder));
+        }
+
+        [Test]
+        public void RegisterReactiveUIViewsFromEntryAssembly_Does_Not_Throw()
+        {
+            var builder = AppBuilder.Configure<Application>();
+            var result = builder.RegisterReactiveUIViewsFromEntryAssembly();
+            Assert.That(result, Is.SameAs(builder));
+        }
+
+        private sealed class TestVm : ReactiveObject, ITestVm
+        {
+        }
+
+        [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+        private sealed class ViewContractAttribute : Attribute
+        {
+            public ViewContractAttribute(string contract)
+            {
+                Contract = contract;
+            }
+
+            public string Contract { get; }
+        }
+
+        private sealed class TestView : UserControl, IViewFor<TestVm>
+        {
+            public TestVm? ViewModel { get; set; }
+
+            object? IViewFor.ViewModel
+            {
+                get => ViewModel;
+                set => ViewModel = (TestVm?)value;
+            }
+        }
+
+        [ViewContract("C1")]
+        private sealed class ContractedTestView : UserControl, IViewFor<TestVm>
+        {
+            public TestVm? ViewModel { get; set; }
+
+            object? IViewFor.ViewModel
+            {
+                get => ViewModel;
+                set => ViewModel = (TestVm?)value;
+            }
+        }
+
+        private sealed class DiBackedView : UserControl, IViewFor<TestVm>
+        {
+            public TestVm? ViewModel { get; set; }
+
+            object? IViewFor.ViewModel
+            {
+                get => ViewModel;
+                set => ViewModel = (TestVm?)value;
+            }
+        }
+    }
+}

--- a/src/Splat.Avalonia.Tests/AutoSuspendHelperTests.cs
+++ b/src/Splat.Avalonia.Tests/AutoSuspendHelperTests.cs
@@ -1,0 +1,61 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Avalonia.Controls.ApplicationLifetimes;
+using NUnit.Framework;
+using ReactiveUI;
+
+namespace ReactiveUI.Avalonia.Tests
+{
+    public class AutoSuspendHelperTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            RxApp.SuspensionHost.IsResuming = Observable.Never<Unit>();
+            RxApp.SuspensionHost.IsLaunchingNew = new Subject<Unit>();
+            RxApp.SuspensionHost.ShouldPersistState = Observable.Never<IDisposable>();
+            RxApp.SuspensionHost.ShouldInvalidateState = Observable.Never<Unit>();
+        }
+
+        [Test]
+        public void Ctor_With_Null_Lifetime_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AutoSuspendHelper(null!));
+        }
+
+        [Test]
+        public void Ctor_With_DesktopLifetime_Sets_ShouldPersistState()
+        {
+            var lifetime = new ClassicDesktopStyleApplicationLifetime();
+            using var helper = new AutoSuspendHelper(lifetime);
+
+            var notified = false;
+            var sub = RxApp.SuspensionHost.ShouldPersistState.Subscribe(d =>
+            {
+                notified = true;
+                d.Dispose();
+            });
+
+            lifetime.Shutdown(0);
+
+            Assert.That(notified, Is.True);
+            sub.Dispose();
+        }
+
+        [Test]
+        public void OnFrameworkInitializationCompleted_Pushes_IsLaunchingNew()
+        {
+            var lifetime = new ClassicDesktopStyleApplicationLifetime();
+            using var helper = new AutoSuspendHelper(lifetime);
+
+            var count = 0;
+            var sub = RxApp.SuspensionHost.IsLaunchingNew.Subscribe(_ => count++);
+
+            helper.OnFrameworkInitializationCompleted();
+
+            Assert.That(count, Is.EqualTo(1));
+            sub.Dispose();
+        }
+    }
+}

--- a/src/Splat.Avalonia.Tests/AvaloniaCreatesCommandBindingTests.cs
+++ b/src/Splat.Avalonia.Tests/AvaloniaCreatesCommandBindingTests.cs
@@ -1,0 +1,115 @@
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using NUnit.Framework;
+
+namespace ReactiveUI.Avalonia.Tests
+{
+    public class AvaloniaCreatesCommandBindingTests
+    {
+        [Test]
+        public void GetAffinityForObject_Returns_Expected()
+        {
+            var sut = new AvaloniaCreatesCommandBinding();
+
+            Assert.That(sut.GetAffinityForObject(typeof(object), hasEventTarget: false), Is.EqualTo(0));
+            Assert.That(sut.GetAffinityForObject(typeof(InputElement), hasEventTarget: false), Is.EqualTo(0));
+            Assert.That(sut.GetAffinityForObject(typeof(InputElement), hasEventTarget: true), Is.GreaterThan(0));
+            Assert.That(sut.GetAffinityForObject(typeof(Button), hasEventTarget: false), Is.EqualTo(10));
+        }
+
+        [Test]
+        public void BindCommandToObject_Wires_Button_Command_And_Parameter()
+        {
+            var sut = new AvaloniaCreatesCommandBinding();
+            var cmd = new TestCommand();
+            var btn = new Button();
+            var param = new BehaviorSubject<object?>("p1");
+
+            using var disp = sut.BindCommandToObject(cmd, btn, param)!;
+
+            Assert.That(btn.CommandParameter, Is.EqualTo("p1"));
+
+            param.OnNext("p2");
+            Assert.That(btn.CommandParameter, Is.EqualTo("p2"));
+
+            // Sanity check that binding exists
+            Assert.That(btn.Command, Is.Not.Null);
+
+            disp.Dispose();
+            Assert.That(btn.Command, Is.Null);
+        }
+
+        [Test]
+        public void BindCommandToObject_With_EventName_Binds_InputElement_GotFocus()
+        {
+            var sut = new AvaloniaCreatesCommandBinding();
+            var cmd = new TestCommand();
+            var btn = new Button();
+            var param = new BehaviorSubject<object?>("evt");
+
+            using var disp = sut.BindCommandToObject<RoutedEventArgs>(cmd, btn, param, nameof(InputElement.GotFocus));
+
+            Assert.That(btn.IsEnabled, Is.True);
+
+            cmd.SetCanExecute(false);
+            param.OnNext("evt2");
+            Assert.That(btn.IsEnabled, Is.False);
+
+            cmd.SetCanExecute(true);
+            param.OnNext("evt3");
+            Assert.That(btn.IsEnabled, Is.True);
+
+            btn.RaiseEvent(new RoutedEventArgs(InputElement.GotFocusEvent));
+            Assert.That(cmd.ExecutedCount, Is.EqualTo(1));
+            Assert.That(cmd.LastParameter, Is.EqualTo("evt3"));
+
+            disp.Dispose();
+            Assert.That(btn.IsSet(InputElement.IsEnabledProperty), Is.False);
+        }
+
+        [Test]
+        public void BindCommandToObject_Throws_On_Invalid_Targets_Or_Nulls()
+        {
+            var sut = new AvaloniaCreatesCommandBinding();
+            var cmd = new TestCommand();
+            var param = new BehaviorSubject<object?>(null);
+
+            Assert.Throws<ArgumentNullException>(() => sut.BindCommandToObject(null!, new object(), param));
+            Assert.Throws<ArgumentNullException>(() => sut.BindCommandToObject(cmd, null!, param));
+            Assert.Throws<InvalidOperationException>(() => sut.BindCommandToObject(cmd, new object(), param));
+
+            Assert.Throws<ArgumentNullException>(() => sut.BindCommandToObject<RoutedEventArgs>(null!, new object(), param, "Click"));
+            Assert.Throws<ArgumentNullException>(() => sut.BindCommandToObject<RoutedEventArgs>(cmd, null!, param, "Click"));
+            Assert.Throws<InvalidOperationException>(() => sut.BindCommandToObject<RoutedEventArgs>(cmd, new object(), param, "Click"));
+            Assert.Throws<InvalidOperationException>(() => sut.BindCommandToObject<RoutedEventArgs>(cmd, new Button(), param, "MissingEvent"));
+        }
+
+        private sealed class TestCommand : System.Windows.Input.ICommand
+        {
+            private bool _canExecute = true;
+
+            public event EventHandler? CanExecuteChanged;
+
+            public int ExecutedCount { get; private set; }
+
+            public object? LastParameter { get; private set; }
+
+            public void SetCanExecute(bool can)
+            {
+                _canExecute = can;
+                CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+            }
+
+            public bool CanExecute(object? parameter) => _canExecute;
+
+            public void Execute(object? parameter)
+            {
+                ExecutedCount++;
+                LastParameter = parameter;
+            }
+        }
+    }
+}

--- a/src/Splat.Avalonia.Tests/ReactiveWindowUserControlBindingTests.cs
+++ b/src/Splat.Avalonia.Tests/ReactiveWindowUserControlBindingTests.cs
@@ -1,0 +1,50 @@
+using Avalonia;
+using Avalonia.Controls;
+using NUnit.Framework;
+
+namespace ReactiveUI.Avalonia.Tests
+{
+    public class ReactiveWindowUserControlBindingTests
+    {
+        [Test]
+        public void ReactiveUserControl_DataContext_And_ViewModel_Sync()
+        {
+            var c = new C();
+            var vm = new VM();
+
+            c.DataContext = vm;
+            Assert.That(c.ViewModel, Is.SameAs(vm));
+
+            var vm2 = new VM();
+            c.ViewModel = vm2;
+            Assert.That(c.DataContext, Is.SameAs(vm2));
+        }
+
+        [Test]
+        public void ReactiveUserControl_ViewModel_Set_To_Null_Syncs_DataContext()
+        {
+            var c = new C();
+            var vm = new VM();
+            c.DataContext = vm;
+            Assert.That(c.ViewModel, Is.SameAs(vm));
+
+            c.ViewModel = null;
+            Assert.That(c.DataContext, Is.Null);
+        }
+
+        private sealed class VM : ReactiveObject
+        {
+            private string? _name;
+
+            public string? Name
+            {
+                get => _name;
+                set => this.RaiseAndSetIfChanged(ref _name, value);
+            }
+        }
+
+        private sealed class C : ReactiveUserControl<VM>
+        {
+        }
+    }
+}

--- a/src/Splat.Avalonia.Tests/ViewHostsNavigationTests.cs
+++ b/src/Splat.Avalonia.Tests/ViewHostsNavigationTests.cs
@@ -1,0 +1,114 @@
+using System.Reflection;
+using Avalonia.Controls;
+using NUnit.Framework;
+using ReactiveUI;
+using Splat;
+
+namespace ReactiveUI.Avalonia.Tests
+{
+    public class ViewHostsNavigationTests
+    {
+        [Test]
+        public void ViewModelViewHost_Navigates_To_Resolved_View()
+        {
+            var host = new ViewModelViewHost { DefaultContent = "default" };
+            var vm = new VmB();
+
+            var m = typeof(ViewModelViewHost).GetMethod("NavigateToViewModel", BindingFlags.Instance | BindingFlags.NonPublic);
+            m!.Invoke(host, new object?[] { vm, null });
+
+            Assert.That(host.Content, Is.InstanceOf<ViewB>());
+            Assert.That(((IViewFor)host.Content!).ViewModel, Is.SameAs(vm));
+        }
+
+        [Test]
+        public void ViewModelViewHost_When_No_View_Falls_Back_To_Default()
+        {
+            var host = new ViewModelViewHost { DefaultContent = "default" };
+
+            var m = typeof(ViewModelViewHost).GetMethod("NavigateToViewModel", BindingFlags.Instance | BindingFlags.NonPublic);
+            m!.Invoke(host, new object?[] { new object(), null });
+
+            Assert.That(host.Content, Is.EqualTo("default"));
+        }
+
+        [Test]
+        public void RoutedViewHost_Navigates_To_Resolved_View_When_Router_Set()
+        {
+            var screen = new ScreenImpl();
+            var host = new RoutedViewHost { DefaultContent = "def", Router = screen.Router };
+            var vm = new VmA(screen);
+
+            var m = typeof(RoutedViewHost).GetMethod("NavigateToViewModel", BindingFlags.Instance | BindingFlags.NonPublic);
+            m!.Invoke(host, new object?[] { vm, null });
+
+            Assert.That(host.Content, Is.InstanceOf<ViewA>());
+            Assert.That(((IViewFor)host.Content!).ViewModel, Is.SameAs(vm));
+        }
+
+        [Test]
+        public void RoutedViewHost_No_Router_Falls_Back_To_Default()
+        {
+            var host = new RoutedViewHost { DefaultContent = "def" };
+
+            var m = typeof(RoutedViewHost).GetMethod("NavigateToViewModel", BindingFlags.Instance | BindingFlags.NonPublic);
+            m!.Invoke(host, new object?[] { new object(), null });
+
+            Assert.That(host.Content, Is.EqualTo("def"));
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            Locator.CurrentMutable.Register(() => new ViewA(), typeof(IViewFor<VmA>));
+            Locator.CurrentMutable.Register(() => new ViewB(), typeof(IViewFor<VmB>));
+        }
+
+        private sealed class VmA : ReactiveObject, IRoutableViewModel
+        {
+            public VmA(IScreen screen)
+            {
+                HostScreen = screen;
+            }
+
+            public string? UrlPathSegment => "A";
+
+            public IScreen HostScreen { get; }
+        }
+
+        private sealed class VmB : ReactiveObject
+        {
+        }
+
+        private sealed class ViewA : UserControl, IViewFor<VmA>
+        {
+            public VmA? ViewModel { get; set; }
+
+            object? IViewFor.ViewModel
+            {
+                get => ViewModel;
+                set => ViewModel = (VmA?)value;
+            }
+
+            public override string ToString() => nameof(ViewA);
+        }
+
+        private sealed class ViewB : UserControl, IViewFor<VmB>
+        {
+            public VmB? ViewModel { get; set; }
+
+            object? IViewFor.ViewModel
+            {
+                get => ViewModel;
+                set => ViewModel = (VmB?)value;
+            }
+
+            public override string ToString() => nameof(ViewB);
+        }
+
+        private sealed class ScreenImpl : ReactiveObject, IScreen
+        {
+            public RoutingState Router { get; } = new();
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix

**What is the new behavior?**
<!-- If this is a feature change -->

This PR fixes the event routing mechanism in AvaloniaCreatesCommandBinding and adds comprehensive unit test coverage for Avalonia integration components in ReactiveUI. The fix ensures routed events declared on base classes can be found when binding commands to derived controls.

- Fixed `FindRoutedEvent` to traverse the type hierarchy for proper event resolution
- Added extensive unit tests for command binding, view hosts, user controls, and registration functionality
- Improved test coverage and reliability for Avalonia integration components

**What might this PR break?**

N/A

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

