### PR TITLE
Replace RxApp.MainThreadScheduler with RxSchedulers

### DIFF
--- a/src/ReactiveUI.Avalonia.Autofac/AvaloniaMixins.cs
+++ b/src/ReactiveUI.Avalonia.Autofac/AvaloniaMixins.cs
@@ -49,7 +49,7 @@ public static class AvaloniaMixins
                 var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
                 containerBuilder.RegisterInstance(autofacResolver);
                 autofacResolver.InitializeReactiveUI(RegistrationNamespace.Avalonia);
-                RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
+                RxSchedulers.MainThreadScheduler = AvaloniaScheduler.Instance;
                 containerConfig(containerBuilder);
                 var container = containerBuilder.Build();
                 autofacResolver.SetLifetimeScope(container);

--- a/src/ReactiveUI.Avalonia.DryIoc/AvaloniaMixins.cs
+++ b/src/ReactiveUI.Avalonia.DryIoc/AvaloniaMixins.cs
@@ -46,7 +46,7 @@ public static class AvaloniaMixins
                 var container = new Container();
                 container.UseDryIocDependencyResolver();
                 AppLocator.CurrentMutable.RegisterConstant(container);
-                RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
+                RxSchedulers.MainThreadScheduler = AvaloniaScheduler.Instance;
                 containerConfig(container);
             })
         };

--- a/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/AvaloniaMixins.cs
+++ b/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/AvaloniaMixins.cs
@@ -47,7 +47,7 @@ public static class AvaloniaMixins
                 IServiceCollection serviceCollection = new ServiceCollection();
                 serviceCollection.UseMicrosoftDependencyResolver();
                 AppLocator.CurrentMutable.RegisterConstant(serviceCollection);
-                RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
+                RxSchedulers.MainThreadScheduler = AvaloniaScheduler.Instance;
                 containerConfig(serviceCollection);
                 var serviceProvider = serviceCollection.BuildServiceProvider();
                 serviceProvider.UseMicrosoftDependencyResolver();

--- a/src/ReactiveUI.Avalonia.Ninject/AvaloniaMixins.cs
+++ b/src/ReactiveUI.Avalonia.Ninject/AvaloniaMixins.cs
@@ -46,7 +46,7 @@ public static class AvaloniaMixins
                 var container = new StandardKernel();
                 container.UseNinjectDependencyResolver();
                 AppLocator.CurrentMutable.RegisterConstant(container);
-                RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
+                RxSchedulers.MainThreadScheduler = AvaloniaScheduler.Instance;
                 containerConfig(container);
             })
         };

--- a/src/ReactiveUI.Avalonia/AppBuilderExtensions.cs
+++ b/src/ReactiveUI.Avalonia/AppBuilderExtensions.cs
@@ -39,7 +39,7 @@ public static class AppBuilderExtensions
             }
 
             PlatformRegistrationManager.SetRegistrationNamespaces(RegistrationNamespace.Avalonia);
-            RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
+            RxSchedulers.MainThreadScheduler = AvaloniaScheduler.Instance;
             AppLocator.CurrentMutable.RegisterConstant<IActivationForViewFetcher>(new AvaloniaActivationForViewFetcher());
             AppLocator.CurrentMutable.RegisterConstant<IPropertyBindingHook>(new AutoDataTemplateBindingHook());
             AppLocator.CurrentMutable.RegisterConstant<ICreatesCommandBinding>(new AvaloniaCreatesCommandBinding());
@@ -197,7 +197,7 @@ public static class AppBuilderExtensions
                     AppLocator.CurrentMutable.RegisterConstant(container);
                     var dependencyResolver = dependencyResolverFactory(container);
                     AppLocator.SetLocator(dependencyResolver);
-                    RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
+                    RxSchedulers.MainThreadScheduler = AvaloniaScheduler.Instance;
                     containerConfig(container);
                 })
             };


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the new behavior?**
<!-- If this is a feature change -->

Updated all usages of RxApp.MainThreadScheduler to RxSchedulers.MainThreadScheduler in Avalonia mixins and AppBuilderExtensions. This change aligns with the updated ReactiveUI API and ensures consistent scheduler assignment across supported DI containers.

**What might this PR break?**

RxSchedulers replaces original RxApp usage for Schedulers

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

