### PR TITLE
breaking: Remove netstandard2.0 from AvaloniaTargetFrameworks

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,7 +32,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <AvaloniaTargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</AvaloniaTargetFrameworks>
+    <AvaloniaTargetFrameworks>net8.0;net9.0;net10.0</AvaloniaTargetFrameworks>
     <AvaloniaTestTargetFrameworks>net8.0;net9.0;net10.0</AvaloniaTestTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">


### PR DESCRIPTION
This pull request makes a breaking update to the supported target frameworks for Avalonia in the project configuration. The change removes support for `netstandard2.0`, ensuring that Avalonia is only targeted for more recent .NET versions. No other changes are included.

Splat no longer supports netstandard2.0 so net8 or above is a prerequisite now. This is to avoid bugs in ReactiveUI targetting out of date target frameworks.
