### PR TITLE
housekeeping: Remove unused Microsoft.CodeAnalysis packages

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,8 +16,6 @@
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />


### PR DESCRIPTION

- Removed `Microsoft.CodeAnalysis.Analyzers` and `Microsoft.CodeAnalysis.CSharp.Workspaces` package version declarations from `src/Directory.Packages.props` which are unused.